### PR TITLE
add workaround for different build target names

### DIFF
--- a/libs/my-parent-lib/project.json
+++ b/libs/my-parent-lib/project.json
@@ -5,6 +5,7 @@
   "projectType": "library",
   "targets": {
     "new-build": {
+      "dependsOn": ["^new-build"],
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {

--- a/libs/mylib/project.json
+++ b/libs/mylib/project.json
@@ -4,6 +4,14 @@
   "sourceRoot": "libs/mylib/src",
   "projectType": "library",
   "targets": {
+    "new-build": {
+      "dependsOn": ["build"],
+      "command": "echo dummy build",
+      "options": {
+        "outputPath": "dist/libs/mylib",
+        "tsConfig": "libs/mylib/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],


### PR DESCRIPTION
Allows `nx new-build my-parent-lib` to work with current contraints.